### PR TITLE
fix issue #15

### DIFF
--- a/native/build.gradle
+++ b/native/build.gradle
@@ -44,6 +44,10 @@ test {
             print "${result.successfulTestCount} successes, "
             print "${result.failedTestCount} failures, "
             println "${result.skippedTestCount} skipped)"
+
+            if(result.skippedTestCount > 0){
+                throw new RuntimeException("Tests cannot be skipped for wgpuj/native!");
+            }
         }
     }
 }

--- a/native/src/test/java/com/noahcharlton/wgpuj/WgpuNativeTest.java
+++ b/native/src/test/java/com/noahcharlton/wgpuj/WgpuNativeTest.java
@@ -8,6 +8,8 @@ import jnr.ffi.Runtime;
 
 public class WgpuNativeTest {
 
+    private static final RustFailCallback callback = new RustFailCallback.RustFailCallbackImpl();
+
     protected static WgpuTest wgpuTest;
 
     static {
@@ -17,7 +19,7 @@ public class WgpuNativeTest {
             wgpuTest = LibraryLoader.create(WgpuTest.class).load(file.getAbsolutePath());
             WgpuJava.setRuntime(Runtime.getRuntime(wgpuTest));
 
-            wgpuTest.set_fail_callback(new RustFailCallback.RustFailCallbackImpl());
+            wgpuTest.set_fail_callback(callback);
         }catch(Exception e){
             System.err.println("Failed to initialize wgpu test library!");
 

--- a/native/src/test/java/com/noahcharlton/wgpuj/WgpuTypeTests.java
+++ b/native/src/test/java/com/noahcharlton/wgpuj/WgpuTypeTests.java
@@ -48,7 +48,6 @@ import com.noahcharlton.wgpuj.jni.WgpuTextureViewDimension;
 import com.noahcharlton.wgpuj.util.RustCString;
 import jnr.ffi.Pointer;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -174,8 +173,8 @@ public class WgpuTypeTests extends WgpuNativeTest {
         );
     }
 
-    @Test
-    @Disabled("CLimits has private fields")
+//  --- Blocked by wgpu-native having a private field ---
+//  @Test
     void cLimitsMaxBindGroupsTest() {
         var cLimits = WgpuCLimits.createDirect();
         cLimits.setMaxBindGroups(951);


### PR DESCRIPTION
Fixes issue #15 by making the fall callback a field of WgpuNativeTest. This is needed because jnr does not keep a reference to the callback, so it is GC'd away.  See https://github.com/lmdbjava/lmdbjava/issues/125 for more details.

This commit also makes it so that wgpu-java/native will fail if any of the tests are skipped. This is because if rust code panics, the JVM will exit and then the test will be skipped automatically.  